### PR TITLE
fix: Seed database in production for Vercel deployment

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -38,14 +38,11 @@ app.use((req, res, next) => {
 });
 
 (async () => {
-  // Initialize database with seed data in development only
-  // In production, this will be handled per-request to work with serverless
-  if (process.env.NODE_ENV === 'development') {
-    try {
-      await storage.seedData();
-    } catch (error) {
-      console.error("Failed to seed data:", error);
-    }
+  // Initialize database with seed data
+  try {
+    await storage.seedData();
+  } catch (error) {
+    console.error("Failed to seed data:", error);
   }
   
   const server = await registerRoutes(app);

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: ['*'],
   };
 
   const vite = await createViteServer({


### PR DESCRIPTION
The application was not seeding the database in the production environment, causing the food truck pages to not show up when deployed to Vercel.

This change removes the condition that restricted database seeding to the development environment, allowing the database to be seeded on Vercel. The seeding function is idempotent, so it is safe to run on every startup.

Additionally, this change fixes a TypeScript type error in `server/vite.ts` by updating the `allowedHosts` configuration.