### PR TITLE
feat: Configure project for Vercel deployment

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+.git
+node_modules
+.replit
+replit.md
+*.md

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "postinstall": "npm run db:push"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -73,7 +74,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "drizzle-kit": "^0.30.4"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
@@ -91,7 +93,6 @@
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
-    "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,7 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as const,
   };
 
   const vite = await createViteServer({

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "buildCommand": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+  "builds": [
+    {
+      "src": "dist/index.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "dist/index.js"
+    }
+  ]
+}


### PR DESCRIPTION
This commit prepares the project for deployment on Vercel.

- Adds a `vercel.json` file to configure the build command and routing.
- Adds a `.vercelignore` file to exclude unnecessary files from the deployment.
- Moves `drizzle-kit` to `dependencies` to make it available in the Vercel build environment.
- Adds a `postinstall` script to run database migrations during deployment.
- Fixes a TypeScript type error in the Vite server configuration.