### PR TITLE
feat(menu): Add new header and menu items for Jolly Frog

### DIFF
--- a/client/src/pages/truck-detail.tsx
+++ b/client/src/pages/truck-detail.tsx
@@ -8,7 +8,21 @@ import { ArrowLeft, MapPin, Phone, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { FoodTruck } from "@shared/schema";
+import type { FoodTruck, MenuCategory } from "@shared/schema";
+
+function isMenuCategorized(menu: any[]): menu is MenuCategory[] {
+  if (!menu || menu.length === 0) {
+    return false;
+  }
+  const firstItem = menu[0];
+  return (
+    typeof firstItem === 'object' &&
+    firstItem !== null &&
+    'category' in firstItem &&
+    'items' in firstItem &&
+    Array.isArray(firstItem.items)
+  );
+}
 
 export default function IndividualFoodTruckDetailPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -156,68 +170,13 @@ export default function IndividualFoodTruckDetailPage() {
                     </CardHeader>
                     <CardContent>
                       <div className="space-y-6">
-                        <div>
-                          
-                          {truck.slug === "fresh-cool" && (
-                            <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Springrolls</h2>
-                          )}
-                          
-                          {truck.slug === "toast" && (
-                            <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Classic Paninis</h2>
-                          )}
-
-                          {/* Jolly Frog */}
-                          {truck.slug === "jolly-frog" ? (
-                            <>
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Tacos with Rice & Beans (2 per order)</h2>
-                              <div className="space-y-4 mb-6">
-                                {truck.menu.slice(0, 3).map((item, index) => (
-                                  <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
-                                    <div className="flex justify-between items-start">
-                                      <div className="flex-1">
-                                        <h5 className="font-medium text-gray-900">{item.name}</h5>
-                                        <p className="text-sm text-gray-600 mt-1">{item.description}</p>
-                                      </div>
-                                      <span className="font-semibold text-primary ml-4">{item.price}</span>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Burrito / Bowl (chips on the side)</h2>
-                              <div className="space-y-4 mb-6">
-                                {truck.menu.slice(3, 5).map((item, index) => (
-                                  <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
-                                    <div className="flex justify-between items-start">
-                                      <div className="flex-1">
-                                        <h5 className="font-medium text-gray-900">{item.name}</h5>
-                                        <p className="text-sm text-gray-600 mt-1">{item.description}</p>
-                                      </div>
-                                      <span className="font-semibold text-primary ml-4">{item.price}</span>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Tostadas with Rice</h2>
-                              <div className="space-y-4 mb-6">
-                                {truck.menu.slice(5, 7).map((item, index) => (
-                                  <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
-                                    <div className="flex justify-between items-start">
-                                      <div className="flex-1">
-                                        <h5 className="font-medium text-gray-900">{item.name}</h5>
-                                        <p className="text-sm text-gray-600 mt-1">{item.description}</p>
-                                      </div>
-                                      <span className="font-semibold text-primary ml-4">{item.price}</span>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Build your own</h2>
+                        {isMenuCategorized(truck.menu) ? (
+                          (truck.menu as MenuCategory[]).map((category, catIndex) => (
+                            <div key={catIndex} className={catIndex < truck.menu.length - 1 ? 'mb-6' : ''}>
+                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">{category.category}</h2>
                               <div className="space-y-4">
-                                {truck.menu.slice(7, 8).map((item, index) => (
-                                  <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
+                                {category.items.map((item, itemIndex) => (
+                                  <div key={itemIndex} className="border-b border-gray-200 pb-3 last:border-b-0">
                                     <div className="flex justify-between items-start">
                                       <div className="flex-1">
                                         <h5 className="font-medium text-gray-900">{item.name}</h5>
@@ -228,8 +187,18 @@ export default function IndividualFoodTruckDetailPage() {
                                   </div>
                                 ))}
                               </div>
-                            </>
-                          ) : (
+                            </div>
+                          ))
+                        ) : (
+                          <div>
+                            {truck.slug === "fresh-cool" && (
+                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Springrolls</h2>
+                            )}
+
+                            {truck.slug === "toast" && (
+                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Classic Paninis</h2>
+                            )}
+
                             <div className="space-y-4">
                               {truck.menu.map((item, index) => (
                                 <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
@@ -243,9 +212,8 @@ export default function IndividualFoodTruckDetailPage() {
                                 </div>
                               ))}
                             </div>
-                          )}
-                          
-                        </div>
+                          </div>
+                        )}
                       </div>
                     </CardContent>
                   </Card>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -229,14 +229,41 @@ export class MemStorage implements IStorage {
           facebook: "https://www.facebook.com/jollyfrogllc?mibextid=wwXIfr"
         },
         menu: [
-          { name: "Steak and/or Pork", price: "$10.00", description: "Corn tortilla, onion, cilantro, lime." },
-          { name: "Chicken", price: "$10.00", description: "Corn tortilla, lettuce, sour cream, cheese." },
-          { name: "Veggie", price: "$10.00", description: "Corn tortilla, onion, cilantro, lettuce, tomato, sour cream, cheese, avocado." },
-          { name: "Steak, Chicken, and/or Pork", price: "$12.00", description: "Flour tortilla, rice, beans, onion, cilantro, lettuce, cheese, sour cream." },
-          { name: "Veggie", price: "$12.00", description: "Flour tortilla, rice, beans, onion, cilantro, lettuce, tomato, avocado, cheese, sour cream." },
-          { name: "Vegetarian Black Bean Tacos", price: "$3.00", description: "Seasoned black beans with corn salsa and avocado on corn tortillas." },
-          { name: "Elote (Mexican Street Corn)", price: "$5.50", description: "Grilled corn with mayo, cotija cheese, chili powder, and lime." },
-          { name: "Churros", price: "$4.00", description: "Fresh churros dusted with cinnamon sugar and served with chocolate sauce." }
+          {
+            category: "Tacos with Rice & Beans (2 per order)",
+            items: [
+              { name: "Steak and/or Pork", price: "$10.00", description: "Corn tortilla, onion, cilantro, lime." },
+              { name: "Chicken", price: "$10.00", description: "Corn tortilla, lettuce, sour cream, cheese." },
+              { name: "Veggie", price: "$10.00", description: "Corn tortilla, onion, cilantro, lettuce, tomato, sour cream, cheese, avocado." },
+            ]
+          },
+          {
+            category: "Burrito / Bowl (chips on the side)",
+            items: [
+              { name: "Steak, Chicken, and/or Pork", price: "$12.00", description: "Flour tortilla, rice, beans, onion, cilantro, lettuce, cheese, sour cream." },
+              { name: "Veggie", price: "$12.00", description: "Flour tortilla, rice, beans, onion, cilantro, lettuce, tomato, avocado, cheese, sour cream." },
+            ]
+          },
+          {
+            category: "Tostadas with Rice",
+            items: [
+              { name: "Vegetarian Black Bean Tacos", price: "$3.00", description: "Seasoned black beans with corn salsa and avocado on corn tortillas." },
+              { name: "Elote (Mexican Street Corn)", price: "$5.50", description: "Grilled corn with mayo, cotija cheese, chili powder, and lime." },
+            ]
+          },
+          {
+            category: "Build your own",
+            items: [
+              { name: "Churros", price: "$4.00", description: "Fresh churros dusted with cinnamon sugar and served with chocolate sauce." }
+            ]
+          },
+          {
+            category: "Sides",
+            items: [
+              { name: "TBD", price: "$TBD", description: "TBD" },
+              { name: "TBD", price: "$TBD", description: "TBD" }
+            ]
+          }
         ],
         schedule: {
           "Monday": "11:00 am - 3:00 pm",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -11,7 +11,7 @@ export const foodTrucks = pgTable("food_trucks", {
   category: text("category").notNull(),
   location: text("location").notNull(),
   phone: text("phone").notNull(),
-  menu: json("menu").$type<MenuItem[]>().notNull(),
+  menu: json("menu").$type<MenuItem[] | MenuCategory[]>().notNull(),
   schedule: json("schedule").$type<Schedule>().notNull(),
   businessLinks: json("business_links").$type<BusinessLinks>(),
 });
@@ -20,6 +20,11 @@ export interface MenuItem {
   name: string;
   price: string;
   description: string;
+}
+
+export interface MenuCategory {
+  category: string;
+  items: MenuItem[];
 }
 
 export interface Schedule {


### PR DESCRIPTION
- Refactors the menu data structure to be category-based, making it more robust and scalable.
- Updates the frontend to dynamically render the menu based on the new structure.
- Adds a new "Sides" category and two "TBD" menu items to the Jolly Frog food truck page as requested.
- Updates the shared schema to support both flat and categorized menu structures.