### PR TITLE
Add Nachos section to Jolly Frog menu and two menu items

### DIFF
--- a/client/src/pages/truck-detail.tsx
+++ b/client/src/pages/truck-detail.tsx
@@ -215,8 +215,23 @@ export default function IndividualFoodTruckDetailPage() {
                               </div>
 
                               <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Build your own</h2>
-                              <div className="space-y-4">
+                              <div className="space-y-4 mb-6">
                                 {truck.menu.slice(7, 8).map((item, index) => (
+                                  <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
+                                    <div className="flex justify-between items-start">
+                                      <div className="flex-1">
+                                        <h5 className="font-medium text-gray-900">{item.name}</h5>
+                                        <p className="text-sm text-gray-600 mt-1">{item.description}</p>
+                                      </div>
+                                      <span className="font-semibold text-primary ml-4">{item.price}</span>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+
+                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Nachos</h2>
+                              <div className="space-y-4">
+                                {truck.menu.slice(8, 10).map((item, index) => (
                                   <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
                                     <div className="flex justify-between items-start">
                                       <div className="flex-1">

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -236,7 +236,9 @@ export class MemStorage implements IStorage {
           { name: "Veggie", price: "$12.00", description: "Flour tortilla, rice, beans, onion, cilantro, lettuce, tomato, avocado, cheese, sour cream." },
           { name: "Vegetarian Black Bean Tacos", price: "$3.00", description: "Seasoned black beans with corn salsa and avocado on corn tortillas." },
           { name: "Elote (Mexican Street Corn)", price: "$5.50", description: "Grilled corn with mayo, cotija cheese, chili powder, and lime." },
-          { name: "Churros", price: "$4.00", description: "Fresh churros dusted with cinnamon sugar and served with chocolate sauce." }
+          { name: "Churros", price: "$4.00", description: "Fresh churros dusted with cinnamon sugar and served with chocolate sauce." },
+          { name: "TBD", price: "$TBD", description: "TBD" },
+          { name: "TBD", price: "$TBD", description: "TBD" }
         ],
         schedule: {
           "Monday": "11:00 am - 3:00 pm",


### PR DESCRIPTION
Includes a new header and two placeholder menu items with 'TBD' values for the name, price, and description.

Changes:
- Modified `server/storage.ts` to include the new menu items in the data source.
- Updated `client/src/pages/truck-detail.tsx` to render the new 'Nachos' section and its corresponding menu items.