### PR TITLE
Adds subheadings to the Roost food truck menu sections.

### DIFF
--- a/client/src/pages/truck-detail.tsx
+++ b/client/src/pages/truck-detail.tsx
@@ -250,7 +250,10 @@ export default function IndividualFoodTruckDetailPage() {
                             </>
                           ) : truck.slug === "roost" ? (
                             <>
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Jumbo 1/4 lb Chicken Tenders</h2>
+                              <div className="flex justify-between items-baseline mb-4">
+                                <h2 className="text-lg font-semibold text-gray-900 underline">Jumbo 1/4 lb Chicken Tenders</h2>
+                                <span className="font-semibold text-gray-900">Tenders / Meal</span>
+                              </div>
                               <div className="space-y-4 mb-6">
                                 {truck.menu.slice(0, 3).map((item, index) => (
                                   <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
@@ -265,7 +268,10 @@ export default function IndividualFoodTruckDetailPage() {
                                 ))}
                               </div>
 
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Chicken Sandwiches</h2>
+                              <div className="flex justify-between items-baseline mb-4">
+                                <h2 className="text-lg font-semibold text-gray-900 underline">Chicken Sandwiches</h2>
+                                <span className="font-semibold text-gray-900">Sandwich / Meal</span>
+                              </div>
                               <div className="space-y-4 mb-6">
                                 {truck.menu.slice(3, 6).map((item, index) => (
                                   <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">
@@ -280,7 +286,10 @@ export default function IndividualFoodTruckDetailPage() {
                                 ))}
                               </div>
 
-                              <h2 className="text-lg font-semibold text-gray-900 mb-4 underline">Sides</h2>
+                              <div className="flex justify-between items-baseline mb-4">
+                                <h2 className="text-lg font-semibold text-gray-900 underline">Sides</h2>
+                                <span className="font-semibold text-gray-900">Small / Large</span>
+                              </div>
                               <div className="space-y-4 mb-6">
                                 {truck.menu.slice(6, 9).map((item, index) => (
                                   <div key={index} className="border-b border-gray-200 pb-3 last:border-b-0">

--- a/server.log
+++ b/server.log
@@ -1,0 +1,3 @@
+
+> rest-express@1.0.0 dev
+> NODE_ENV=development tsx server/index.ts

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -24,7 +24,7 @@ export async function setupVite(app: Express, server: Server) {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,
-  };
+  } as const;
 
   const vite = await createViteServer({
     ...viteConfig,


### PR DESCRIPTION
This commit introduces the following changes:
- Adds "Tenders / Meal" to the "Jumbo 1/4 lb Chicken Tenders" section.
- Adds "Sandwich / Meal" to the "Chicken Sandwiches" section.
- Adds "Small / Large" to the "Sides" section.

The new subheadings are aligned to the right of the main section headers using flexbox.

This also includes a fix for a TypeScript type error in `server/vite.ts` that was discovered during pre-commit checks.