### PR TITLE
remove find a cart button and fix carts nav scroll offset

### DIFF
--- a/client/src/components/header.tsx
+++ b/client/src/components/header.tsx
@@ -84,13 +84,6 @@ export default function SiteNavigationHeader() {
             </div>
           </nav>
 
-          <button
-            className="header-cta"
-            onClick={() => scrollToSection('carts')}
-          >
-            Find a Cart
-          </button>
-
           <div className="mobile-menu-section">
             <Button
               variant="ghost"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -176,7 +176,7 @@ html {
 }
 
 .desktop-navigation {
-  @apply hidden md:block ml-auto mr-6;
+  @apply hidden md:block ml-auto;
 }
 
 .desktop-nav-links {
@@ -208,25 +208,6 @@ html {
 .contact-nav-button:hover {
   opacity: 1;
   border-color: var(--gold);
-}
-
-.header-cta {
-  @apply hidden md:inline-flex;
-  background: var(--gold);
-  color: var(--red-deep);
-  font-family: 'Archivo', sans-serif;
-  font-weight: 800;
-  font-size: 0.85rem;
-  border: none;
-  cursor: pointer;
-  padding: 0.6rem 1.3rem;
-  border-radius: 100px;
-  transition: all 0.2s ease;
-}
-
-.header-cta:hover {
-  background: #ffc84a;
-  transform: translateY(-1px);
 }
 
 .mobile-menu-section {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,22 +7,26 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Measures the real height of any sticky chrome (header, and the filter bar
- * when it's present and sticky at this viewport) so section scroll targets
- * land below it instead of underneath it. Avoids hardcoded offsets that
- * silently drift whenever the header or filter bar's height changes.
+ * Measures the real height of the sticky chrome sitting above a scroll target,
+ * so sections land below it instead of underneath it. Avoids hardcoded offsets
+ * that silently drift whenever the header or filter bar's height changes.
+ *
+ * The filter bar only counts when it is sticky *and* sits outside the target:
+ * it lives inside the carts section, so counting it there would offset past
+ * the section's own top and reveal the hero above it.
  */
-export function getStickyChromeHeight(): number {
+export function getStickyChromeHeight(target?: Element | null): number {
   const header = document.querySelector(".main-header");
   const headerHeight = header ? header.getBoundingClientRect().height : 0;
 
   // The filter bar is only sticky at some viewports, so ask the browser rather
   // than assuming — at widths where it scrolls away it must not be counted.
   const filterBar = document.querySelector(".search-filter-section");
-  const filterBarHeight =
-    filterBar && window.getComputedStyle(filterBar).position === "sticky"
-      ? filterBar.getBoundingClientRect().height
-      : 0;
+  const filterBarCounts =
+    filterBar &&
+    window.getComputedStyle(filterBar).position === "sticky" &&
+    !target?.contains(filterBar);
+  const filterBarHeight = filterBarCounts ? filterBar.getBoundingClientRect().height : 0;
 
   return headerHeight + filterBarHeight + 16; // small breathing room below the sticky chrome
 }
@@ -30,7 +34,7 @@ export function getStickyChromeHeight(): number {
 export function scrollToSectionId(sectionId: string) {
   const element = document.getElementById(sectionId);
   if (!element) return;
-  const top = element.getBoundingClientRect().top + window.scrollY - getStickyChromeHeight();
+  const top = element.getBoundingClientRect().top + window.scrollY - getStickyChromeHeight(element);
   window.scrollTo({ top, behavior: "smooth" });
 }
 

--- a/client/src/pages/cart-detail.tsx
+++ b/client/src/pages/cart-detail.tsx
@@ -4,7 +4,7 @@ import { Link } from "wouter";
 import SiteNavigationHeader from "@/components/header";
 import SiteContactFooter from "@/components/footer";
 import { isCurrentlyOpen, capitalizeFirst } from "@/lib/utils";
-import { ArrowLeft, MapPin, Clock, Globe, Link2, ShoppingBag } from "lucide-react";
+import { ArrowLeft, MapPin, Clock, Globe, Link2, ShoppingBag, FileText, Monitor } from "lucide-react";
 import React from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDocumentMeta } from "@/hooks/use-document-meta";
@@ -573,7 +573,7 @@ export default function IndividualFoodCartDetailPage() {
 
                   <div className="stub-block">
                     <div className="stub-block-label">
-                      <MapPin size={13} />
+                      <FileText size={13} />
                       About
                     </div>
                     <p className="stub-desc">{cart.description}</p>
@@ -606,7 +606,7 @@ export default function IndividualFoodCartDetailPage() {
                   {showBusinessLinks && hasBusinessLinks && (
                     <div className="stub-block">
                       <div className="stub-block-label">
-                        <ShoppingBag size={13} />
+                        <Monitor size={13} />
                         Find Them Online
                       </div>
                       <div className="stub-links">


### PR DESCRIPTION
The sticky-chrome helper subtracted the filter bar's height even when that bar sits inside the scroll target. Because the filter bar lives within #carts, the nav overshot upward and exposed the hero. Only count the bar when it is outside the target.

Also swap the cart detail about icon to a document and find-them-online to a monitor, and drop the nav right margin left over from the CTA.